### PR TITLE
Add ESLint config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: js
+
+cache:
+  yarn: true
+  directories:
+    - node_modules
+
+script:
+  - echo "There are currently no moving parts to test"
+
+deploy:
+  - provider: npm
+    verbose: true
+    email: developers@healthengine.com.au
+    api_key:
+      secure: Srf53BKj0RaIrOTkhiI5wwGEgf1YZ/RIxvTfd3lYpJrPa0ooGSIdVlniwhLR7aAq+y8PyCrW/J2rdR/Z0uihSJsz1YDDxMdHv2RUIhI/IiV+aOU/DQeSMn0f9tyMbom9D2HIzDEiwu7wKLAhJU0i6g2WjUfcFJoUUZqPXJW8jWbeOhfS1Ye9rVzMHIJvDaM4IN0RhjkCNocVjXnavkPX6+nsrwMo8kWOxDHR9uSrWiPHVCQqzOVD3EeoGEg+NuB7rRIYsU3jepkdqvPmZq5ynjX3d6D084m9K11f2Z8rDAexB2bQY1Rd8GvFAT6T6ZLGTIoHicbSMgtlcsmmjgrvRo3Q6CmSeUxJNzirdA/DnaNMQp6VOag1vbdt9yY4Q8ljGnpt5pM2jHZkFXrAkT6ePsaqVFkuOmzRVf4OrxGAp15qna9jwWEc8CrWvFyU2NwvCGhlRz3+t50Z8I+hxhiE1t3U0z4aSaGj6pkBXrr8APbprkuR9UUrpaHt7sKLepXKyBKxV/NerN2XlXsOgQw+Igti8dVixO16Aem9eXKbqfLuzHlFSXIGMOHy1/BHQ4zDJAQxXvcDkGvXCMnlbG3HNzWMhJ3y6UUAqMaqoaTYr4bfHyD9SMr9SFedbnBfYGuVvhfRPNGiB5D1GCa3vu8qi/DGjJhgKGdCt1Mr/QbVMes=
+    on:
+      tags: true
+    skip-cleanup: true
+
+notifications:
+  slack:
+    secure: vqLBHGlx4cZ9bzVN59w9HGztu03tDX/vMVt/C9s+qDZFOv1+VCRaEzInBw99vpxgGBnm364VgXtYXFk6H1GAuFe8j20ydaqi/mVUnHRRb8akC5YpyL6aar7ACs6LDHuUvmIjCV4QVZxHWHl+ppRgZ0XZHvHuKG+bpiLMPpwQEDFHajxaFdghtxFxeTO4BaSSB2/rD1WXPshLOixCo2tK78h9IJndhXo4PFUNSC+wgYHdaVoVRDmRLUDf3dnRswLXP2GbQFW4yZU8rqnkDT/Y2tCV1cLA0flqOez4DEVHrs1jgghJ5FBzwLCVvHAwbFsESbAl0bMA7dgErJQVMkvujTBl7+SW/X94OicwmjTxOUb3S9sEb3F3+WZMaolHnksZydmexyD+Vw4p3JuDZHICaYdjqYayvSgOanVcfyY+NawE8RmjepiTY2QDlaNCeQ82r8hakoh3xITVO8/Htm5n5e9m+m2voieiGtIGeNHGYzYlQj28qwb20+K9Xh0PRi2ZMhY/qowh15mBtbLKJZDCFZ1waIIBjq+hAgkVpaBrdS5vi2uJQgGayfmsYcHJ6qxUd1Q9Vz2DChu/GUfX7WoAU28CCliHbSpmk+wYkRRZ4gL22V8uSEKtg7dUmjG9QQx4nw5GEAqtjHG6XYnnVz86UliuntmP7P+bw1qWvRDYjGw=

--- a/index.js
+++ b/index.js
@@ -9,18 +9,18 @@ module.exports = {
         jsx: true,
       },
     },
-
+  
     extends: [
       // Airbnb provides almost all our linting rules
       'airbnb',
-
+  
       // Flowtype allows us to use flow type declarations
       'plugin:flowtype/recommended',
-
+  
       // Prettier provides opinionated defaults for all code-layout choices
       'plugin:prettier/recommended',
     ],
-
+  
     // Allows assuming the presence of globals provided by all these environments
     env: {
       es6: true,
@@ -29,10 +29,12 @@ module.exports = {
       mocha: true,
       jest: true,
     },
-
-    // Allows linting type-declarations
-    plugins: ['flowtype'],
-
+  
+    plugins: [
+        // Allows linting type-declarations
+        'flowtype',
+    ],
+  
     rules: {
       // Downgrades these accessibility rules to warnings while we decide on policy
       "jsx-a11y/interactive-supports-focus": 1,
@@ -44,28 +46,31 @@ module.exports = {
       
       // Allows importing from files with explicit '.js' extensions
       'import/extensions': 0,
-
+  
       // Allows default props to be set when destructuring
       'react/require-default-props': 0,
-
+  
       // Allows using object/any as prop types
       'react/forbid-prop-types': 0,
-
+  
       // Class-based components are still needed when using refs
       'react/prefer-stateless-function': 0,
-
+  
       // Permits normal '.js' files to use inline JSX
       'react/jsx-filename-extension': 0,
-
+  
       // Permits defining proptypes in flow instead
       'react/prop-types': 1,
-
+  
       // Downgrades bad array keys to a warning
       'react/no-array-index-key': 1,
-
+  
       // Downgrades unescaped HTML entity literals to a warning 
       'react/no-unescaped-entities': 1,
-
+  
+      // Prevent assigning to arguments, but allow modifying them.
+      "no-param-reassign": [2, {props: false}],
+  
       // Applies our code-layout customizations
       'prettier/prettier': [
         2,

--- a/index.js
+++ b/index.js
@@ -31,19 +31,19 @@ module.exports = {
     },
   
     plugins: [
-        // Allows linting type-declarations
-        'flowtype',
+      // Allows linting type-declarations
+      'flowtype',
     ],
   
     rules: {
       // Downgrades these accessibility rules to warnings while we decide on policy
-      "jsx-a11y/interactive-supports-focus": 1,
-      "jsx-a11y/click-events-have-key-events": 1,
-      "jsx-a11y/no-noninteractive-element-interactions": 1,
-      "jsx-a11y/no-static-element-interactions": 1,
-      "jsx-a11y/label-has-for": 1,
-      "jsx-a11y/anchor-is-valid": 1,
-      
+      'jsx-a11y/interactive-supports-focus': 1,
+      'jsx-a11y/click-events-have-key-events': 1,
+      'jsx-a11y/no-noninteractive-element-interactions': 1,
+      'jsx-a11y/no-static-element-interactions': 1,
+      'jsx-a11y/label-has-for': 1,
+      'jsx-a11y/anchor-is-valid': 1,
+  
       // Allows importing from files with explicit '.js' extensions
       'import/extensions': 0,
   
@@ -65,11 +65,11 @@ module.exports = {
       // Downgrades bad array keys to a warning
       'react/no-array-index-key': 1,
   
-      // Downgrades unescaped HTML entity literals to a warning 
+      // Downgrades unescaped HTML entity literals to a warning
       'react/no-unescaped-entities': 1,
   
       // Prevent assigning to arguments, but allow modifying them.
-      "no-param-reassign": [2, {props: false}],
+      'no-param-reassign': [2, { props: false }],
   
       // Applies our code-layout customizations
       'prettier/prettier': [

--- a/index.js
+++ b/index.js
@@ -1,0 +1,46 @@
+module.exports = {
+    "parser": "babel-eslint",
+    "parserOptions": {
+      "ecmaVersion": 7,
+      "sourceType": "module",
+      "ecmaFeatures": {
+        "experimentalObjectRestSpread": true,
+        "jsx": true
+      }
+    },
+    "extends": [
+      "airbnb",
+      "prettier"
+    ],
+    "env": {
+      "es6": true,
+      "browser": true,
+      "node": true,
+      "mocha": true,
+      "jest": true
+    },
+    "plugins": [
+      "import",
+      "react",
+      "babel",
+      "prettier"
+    ],
+    "rules": {
+      "react/require-default-props": 0,
+      "react/forbid-prop-types": 0,
+      "react/prefer-stateless-function": 0,
+      "react/jsx-filename-extension": 0,
+      "func-names": 0,
+      "no-else-return": 0,
+      "one-var": 0,
+      "import/first": 1,
+      "react/prop-types": 1,
+      "no-param-reassign": [
+        2,
+        {
+          "props": false
+        }
+      ],
+      "prettier/prettier": "error"
+    }
+  }

--- a/index.js
+++ b/index.js
@@ -1,38 +1,79 @@
 module.exports = {
-  parser: 'babel-eslint',
-  parserOptions: {
-    ecmaVersion: 7,
-    sourceType: 'module',
-    ecmaFeatures: {
-      experimentalObjectRestSpread: true,
-      jsx: true,
-    },
-  },
-  extends: [
-    'airbnb',
-    'plugin:flowtype/recommended',
-    'plugin:prettier/recommended',
-  ],
-  env: {
-    es6: true,
-    browser: true,
-    node: true,
-    mocha: true,
-    jest: true,
-  },
-  plugins: ['flowtype'],
-  rules: {
-    'react/require-default-props': 0,
-    'react/forbid-prop-types': 0,
-    'react/prefer-stateless-function': 0,
-    'react/jsx-filename-extension': 0,
-    'react/prop-types': 1,
-    'prettier/prettier': [
-      2,
-      {
-        singleQuote: true,
-        trailingComma: 'all',
+    // babel-eslint allows us to include type-hints
+    parser: 'babel-eslint',
+    parserOptions: {
+      ecmaVersion: 7,
+      sourceType: 'module',
+      ecmaFeatures: {
+        experimentalObjectRestSpread: true,
+        jsx: true,
       },
+    },
+
+    extends: [
+      // Airbnb provides almost all our linting rules
+      'airbnb',
+
+      // Flowtype allows us to use flow type declarations
+      'plugin:flowtype/recommended',
+
+      // Prettier provides opinionated defaults for all code-layout choices
+      'plugin:prettier/recommended',
     ],
-  },
-};
+
+    // Allows assuming the presence of globals provided by all these environments
+    env: {
+      es6: true,
+      browser: true,
+      node: true,
+      mocha: true,
+      jest: true,
+    },
+
+    // Allows linting type-declarations
+    plugins: ['flowtype'],
+
+    rules: {
+      // Downgrades these accessibility rules to warnings while we decide on policy
+      "jsx-a11y/interactive-supports-focus": 1,
+      "jsx-a11y/click-events-have-key-events": 1,
+      "jsx-a11y/no-noninteractive-element-interactions": 1,
+      "jsx-a11y/no-static-element-interactions": 1,
+      "jsx-a11y/label-has-for": 1,
+      "jsx-a11y/anchor-is-valid": 1,
+      
+      // Allows importing from files with explicit '.js' extensions
+      'import/extensions': 0,
+
+      // Allows default props to be set when destructuring
+      'react/require-default-props': 0,
+
+      // Allows using object/any as prop types
+      'react/forbid-prop-types': 0,
+
+      // Class-based components are still needed when using refs
+      'react/prefer-stateless-function': 0,
+
+      // Permits normal '.js' files to use inline JSX
+      'react/jsx-filename-extension': 0,
+
+      // Permits defining proptypes in flow instead
+      'react/prop-types': 1,
+
+      // Downgrades bad array keys to a warning
+      'react/no-array-index-key': 1,
+
+      // Downgrades unescaped HTML entity literals to a warning 
+      'react/no-unescaped-entities': 1,
+
+      // Applies our code-layout customizations
+      'prettier/prettier': [
+        2,
+        {
+          singleQuote: true,
+          trailingComma: 'all',
+        },
+      ],
+    },
+  };
+  

--- a/index.js
+++ b/index.js
@@ -21,7 +21,6 @@ module.exports = {
     },
     "plugins": [
       "import",
-      "babel",
       "prettier"
     ],
     "rules": {

--- a/index.js
+++ b/index.js
@@ -21,7 +21,6 @@ module.exports = {
     },
     "plugins": [
       "import",
-      "react",
       "babel",
       "prettier"
     ],

--- a/index.js
+++ b/index.js
@@ -1,43 +1,38 @@
 module.exports = {
-    "parser": "babel-eslint",
-    "parserOptions": {
-      "ecmaVersion": 7,
-      "sourceType": "module",
-      "ecmaFeatures": {
-        "experimentalObjectRestSpread": true,
-        "jsx": true
-      }
+  parser: 'babel-eslint',
+  parserOptions: {
+    ecmaVersion: 7,
+    sourceType: 'module',
+    ecmaFeatures: {
+      experimentalObjectRestSpread: true,
+      jsx: true,
     },
-    "extends": [
-      "airbnb",
-      "prettier"
+  },
+  extends: [
+    'airbnb',
+    'plugin:flowtype/recommended',
+    'plugin:prettier/recommended',
+  ],
+  env: {
+    es6: true,
+    browser: true,
+    node: true,
+    mocha: true,
+    jest: true,
+  },
+  plugins: ['flowtype'],
+  rules: {
+    'react/require-default-props': 0,
+    'react/forbid-prop-types': 0,
+    'react/prefer-stateless-function': 0,
+    'react/jsx-filename-extension': 0,
+    'react/prop-types': 1,
+    'prettier/prettier': [
+      2,
+      {
+        singleQuote: true,
+        trailingComma: 'all',
+      },
     ],
-    "env": {
-      "es6": true,
-      "browser": true,
-      "node": true,
-      "mocha": true,
-      "jest": true
-    },
-    "plugins": [
-      "prettier"
-    ],
-    "rules": {
-      "react/require-default-props": 0,
-      "react/forbid-prop-types": 0,
-      "react/prefer-stateless-function": 0,
-      "react/jsx-filename-extension": 0,
-      "func-names": 0,
-      "no-else-return": 0,
-      "one-var": 0,
-      "import/first": 1,
-      "react/prop-types": 1,
-      "no-param-reassign": [
-        2,
-        {
-          "props": false
-        }
-      ],
-      "prettier/prettier": "error"
-    }
-  }
+  },
+};

--- a/index.js
+++ b/index.js
@@ -20,7 +20,6 @@ module.exports = {
       "jest": true
     },
     "plugins": [
-      "import",
       "prettier"
     ],
     "rules": {

--- a/package.json
+++ b/package.json
@@ -2,10 +2,17 @@
   "name": "eslint-config-he",
   "version": "0.0.1",
   "description": "HealthEngine's coding style standards",
-  "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+  "peerDependencies": {
+    "eslint": "^4.19.1",
+    "eslint-config-airbnb": "^16.1.0",
+    "eslint-config-prettier": "^2.9.0",
+    "eslint-plugin-flowtype": "^2.48.0",
+    "eslint-plugin-import": "^2.12.0",
+    "eslint-plugin-jsx-a11y": "^6.0.3",
+    "eslint-plugin-prettier": "^2.6.0",
+    "eslint-plugin-react": "^7.8.2"
   },
+  "main": "index.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/HealthEngineAU/eslint-config-he.git"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "eslint-config-he",
+  "version": "0.0.1",
+  "description": "HealthEngine's coding style standards",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/HealthEngineAU/eslint-config-he.git"
+  },
+  "author": "HealthEngine",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/HealthEngineAU/eslint-config-he/issues"
+  },
+  "homepage": "https://github.com/HealthEngineAU/eslint-config-he#readme"
+}


### PR DESCRIPTION
Upon publication to NPM, this can now be installed and then used with the following `.eslintrc`:
```
  {
    "extends": "he"
  }
```